### PR TITLE
Update XCR-Armor.rul

### DIFF
--- a/Ruleset/XCR-Armor.rul
+++ b/Ruleset/XCR-Armor.rul
@@ -11,6 +11,8 @@ armors:
       - 1.2
       - 1.5
       - 1.0
+    corpseBattle:
+      - STR_CORPSE
     weight: 0
     loftempsSet: [ 4 ]
   - type: STR_PERSONAL_ARMOR_UC


### PR DESCRIPTION
This fixes a bug in OpenXcom Version: Extended 6.7.2 (v2020-10-24)

[ERROR] Error processing 'STR_NONE_UC' in armors: Missing battle corpse item(s).